### PR TITLE
Reflect clj-commons taking over maintenance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2 # use CircleCI 2.0 https://circleci.com/docs/2.0/language-clojure/
+jobs:
+  build: # runs not using Workflows must have a `build` job as entry point
+    working_directory: ~/conch
+    docker: # run the steps with Docker
+      - image: circleci/clojure:lein-2.7.1
+    environment: # environment variables for primary container
+      LEIN_ROOT: "true"
+      JVM_OPTS: -Xmx3200m # limit the maximum heap size to prevent out of memory errors
+    steps:
+      - checkout
+      - restore_cache: # restores saved cache if checksum hasn't changed since the last run
+          key: conch-{{ checksum "project.clj" }}
+      - run: lein deps
+      - save_cache: # generate and store cache in the .m2 directory using a key template
+          paths:
+            - ~/.m2
+          key: conch-{{ checksum "project.clj" }}
+      - run: lein testall
+      # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ pom.xml
 .lein*
 *jar
 target
+.nrepl-port

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: clojure
-lein: lein2
-script: lein2 testall

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # conch
 
-[![Build Status](https://secure.travis-ci.org/Raynes/conch.png)](http://travis-ci.org/Raynes/conch)
+[![CircleCI](https://circleci.com/gh/clj-commons/conch.svg?style=svg)](https://circleci.com/gh/clj-commons/conch)
+[![Clojars Project](https://img.shields.io/clojars/v/clj-commons/conch.svg)](https://clojars.org/clj-commons/conch)
+[![cljdoc badge](https://cljdoc.org/badge/clj-commons/conch)](https://cljdoc.org/d/clj-commons/conch)
 
 Conch is actually two libraries. The first, `me.raynes.conch.low-level` is a simple low-level
 interface to the Java process APIs. The second and more interesting library is
@@ -10,11 +12,14 @@ an interface to low-level inspired by the Python
 The general idea is to be able to call programs just like you would call Clojure
 functions. See Usage for examples.
 
+This library is the continuation of Raynes/conch. Sadly Raynes passed away in 2016 so
+the clj-commons clojure organisation has taken over maintenance of this excellent library.git st
+
 ## Installation
 
-In Leiningen:
+With Leiningen:
 
-[![version](https://clojars.org/me.raynes/conch/latest-version.svg)](https://clojars.org/me.raynes/conch)
+    [clj-commons/conch "0.9.2"]
 
 ## Usage
 

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,15 @@
-(defproject me.raynes/conch "0.9.2"
+(defproject clj-commons/conch "0.9.2"
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :url "https://github.com/Raynes/conch"
+  :url "https://github.com/clj-commons/conch"
   :description "A better shell-out library for Clojure."
-  :dependencies [[org.clojure/clojure "1.8.0"]]
-  :aliases {"testall" ["with-profile" "dev,default:dev,1.5,default:dev,1.4,default" "test"]}
-  :profiles {:1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+  :scm {:name "git" :url "https://github.com/clj-commons/conch"}
+  :dependencies [[org.clojure/clojure "1.10.0"]]
+  :aliases {"testall" ["with-profile" "dev,default:dev,1.9,default:dev,1.8,default:dev,1.7,default:dev,1.6,default:dev,1.5,default:dev,1.4,default" "test"]}
+  :profiles {:1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.0"]]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :release {:deploy-repositories {"releases" {:url "https://oss.sonatype.org/service/local/staging/deploy/maven2"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject me.raynes/conch "0.9.1"
+(defproject me.raynes/conch "0.9.2"
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :url "https://github.com/Raynes/conch"

--- a/src/me/raynes/conch.clj
+++ b/src/me/raynes/conch.clj
@@ -234,7 +234,8 @@
 
                   :else result))))
       (catch InterruptedException e
-        (conch/destroy proc)))))
+        (conch/destroy proc)
+        (throw e)))))
 
 (defn execute [name & args]
   (let [end (last args)

--- a/src/me/raynes/conch.clj
+++ b/src/me/raynes/conch.clj
@@ -234,12 +234,6 @@
               :else result)))))
 
 (defn execute [name & args]
-  (let [[[options] args] ((juxt filter remove) map? args)]
-    (if (:background options)
-      (future (run-command name args options))
-      (run-command name args options))))
-
-(defn execute [name & args]
   (let [end (last args)
         in-arg (first (filter #(seq? %) args))
         args (remove #(seq? %) args)

--- a/test/me/raynes/conch_test.clj
+++ b/test/me/raynes/conch_test.clj
@@ -134,3 +134,17 @@
     (testing "Environment is cleared if a program is called with :clear-env"
       (is (= "" (env {:throw true :clear-env true})))
       (is (not= "" (env {:throw true}))))))
+
+(comment
+
+(require '[me.raynes.conch :as sh])
+
+(sh/programs sleep ps grep)
+
+(def f (future (sleep "60")))
+
+(future-cancel f)
+
+(grep "sleep" {:in (ps "-ax")})
+
+)

--- a/test/me/raynes/conch_test.clj
+++ b/test/me/raynes/conch_test.clj
@@ -135,16 +135,13 @@
       (is (= "" (env {:throw true :clear-env true})))
       (is (not= "" (env {:throw true}))))))
 
-(comment
 
-(require '[me.raynes.conch :as sh])
-
-(sh/programs sleep ps grep)
-
-(def f (future (sleep "60")))
-
-(future-cancel f)
-
-(grep "sleep" {:in (ps "-ax")})
-
-)
+(deftest cancel-test
+  (sh/with-programs [sleep ps grep]
+    (testing "Destroy process when thread is interrupted."
+      (let [f (future (sleep "60"))]
+        ;give the task a chance to run
+        (Thread/sleep 1000)
+        ;then cancel
+        (future-cancel f)
+        (is (thrown? ExceptionInfo (grep "sleep" {:in (ps "-ax")})))))))


### PR DESCRIPTION
This is the PR related to https://github.com/clj-commons/conch/issues/2.

Of course the CircleCI, Clojars and cljdoc links/badges are broken because of the new group ID (clj-commons/conch is unknown there).

I'd need a few pointers on how to setup the project onto CircleCI and deploy the latest [bugfixes](https://github.com/clj-commons/conch/pull/1) onto maven central under the clj-commons banner.